### PR TITLE
Make setup python 2 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='mirco.huennefeld@tu-dortmund.de',
     url='https://icecube.wisc.edu/~mhuennefeld/docs/dnn_reco/html/index.html',
     packages=['dnn_reco'],
-    install_requires=['numpy', 'pandas', 'click', 'ruamel.yaml', 'tables',
+    install_requires=['numpy', 'pandas', 'click', 'ruamel.yaml', 'tables==3.5.2',
                       'gitpython', 'tfscripts', 'h5py',
                       ],
     dependency_links=[


### PR DESCRIPTION
Most recent tables version 3.6 is not compatible with python2 anymore.