### PR TITLE
Replace num splits with fine-grained chunk size contorl

### DIFF
--- a/configs/examples/DNNTracks/level2_pre_selection/l2_direction_red_summary_stats_fast.yaml
+++ b/configs/examples/DNNTracks/level2_pre_selection/l2_direction_red_summary_stats_fast.yaml
@@ -90,7 +90,8 @@
 'num_repetitions' : 3
 #'DOM_init_values' : [[[[[0., -0.020098502, -0.014917467, 0.057788417, 0.03707111, 0., 0.]]]]]
 'batch_size' : 32
-'data_handler_num_splits' : 5
+'data_handler_max_events_per_file':
+'data_handler_max_file_chunk_size': 1000
 
 'log_path' : "../logs/{unique_name}"
 

--- a/configs/examples/DNNTracks/level2_pre_selection/l2_energy_visible_red_summary_stats_fast.yaml
+++ b/configs/examples/DNNTracks/level2_pre_selection/l2_energy_visible_red_summary_stats_fast.yaml
@@ -90,7 +90,8 @@
 'num_repetitions' : 3
 #'DOM_init_values' : [[[[[0., -0.020098502, -0.014917467, 0.057788417, 0.03707111, 0., 0.]]]]]
 'batch_size' : 32
-'data_handler_num_splits' : 5
+'data_handler_max_events_per_file':
+'data_handler_max_file_chunk_size': 1000
 
 'log_path' : "../logs/{unique_name}"
 

--- a/configs/examples/DNNTracks/level2_pre_selection/l2_starting_events_0m_red_summary_stats_fast.yaml
+++ b/configs/examples/DNNTracks/level2_pre_selection/l2_starting_events_0m_red_summary_stats_fast.yaml
@@ -90,7 +90,8 @@
 'num_repetitions' : 3
 #'DOM_init_values' : [[[[[0., -0.020098502, -0.014917467, 0.057788417, 0.03707111, 0., 0.]]]]]
 'batch_size' : 32
-'data_handler_num_splits' : 5
+'data_handler_max_events_per_file':
+'data_handler_max_file_chunk_size': 1000
 
 'log_path' : "../logs/{unique_name}"
 

--- a/configs/examples/DNNTracks/level2_pre_selection/l2_starting_events_300m_red_summary_stats_fast.yaml
+++ b/configs/examples/DNNTracks/level2_pre_selection/l2_starting_events_300m_red_summary_stats_fast.yaml
@@ -90,7 +90,8 @@
 'num_repetitions' : 3
 #'DOM_init_values' : [[[[[0., -0.020098502, -0.014917467, 0.057788417, 0.03707111, 0., 0.]]]]]
 'batch_size' : 32
-'data_handler_num_splits' : 5
+'data_handler_max_events_per_file':
+'data_handler_max_file_chunk_size': 1000
 
 'log_path' : "../logs/{unique_name}"
 

--- a/dnn_reco/create_trafo_model.py
+++ b/dnn_reco/create_trafo_model.py
@@ -51,7 +51,8 @@ def main(config_files, log_level):
         "num_jobs": config["trafo_num_jobs"],
         "num_add_files": 1,
         "num_repetitions": 1,
-        "num_splits": config["data_handler_num_splits"],
+        "max_events_per_file": config["data_handler_max_events_per_file"],
+        "max_file_chunk_size": config["data_handler_max_file_chunk_size"],
         "init_values": config["DOM_init_values"],
         "nan_fill_value": config["data_handler_nan_fill_value"],
     }

--- a/dnn_reco/settings/setup_manager.py
+++ b/dnn_reco/settings/setup_manager.py
@@ -147,7 +147,8 @@ class SetupManager:
         "DOM_init_values": 0.0,
         "trafo_norm_constant": 1e-6,
         "data_handler_nan_fill_value": None,
-        "data_handler_num_splits": None,
+        "data_handler_max_events_per_file": None,
+        "data_handler_max_file_chunk_size": None,
     }
 
     def __init__(self, config_files, num_threads=None):

--- a/dnn_reco/train_model.py
+++ b/dnn_reco/train_model.py
@@ -60,7 +60,8 @@ def main(config_files, log_level, num_threads):
         num_jobs=config["num_jobs"],
         num_add_files=config["num_add_files"],
         num_repetitions=config["num_repetitions"],
-        num_splits=config["data_handler_num_splits"],
+        max_events_per_file=config["data_handler_max_events_per_file"],
+        max_file_chunk_size=config["data_handler_max_file_chunk_size"],
         init_values=config["DOM_init_values"],
         nan_fill_value=config["data_handler_nan_fill_value"],
     )
@@ -75,7 +76,8 @@ def main(config_files, log_level, num_threads):
         num_jobs=1,
         num_add_files=1,
         num_repetitions=1,
-        num_splits=config["data_handler_num_splits"],
+        max_events_per_file=config["data_handler_max_events_per_file"],
+        max_file_chunk_size=config["data_handler_max_file_chunk_size"],
         init_values=config["DOM_init_values"],
         nan_fill_value=config["data_handler_nan_fill_value"],
     )


### PR DESCRIPTION
Replace `num_splits` with `max_events_per_file` and `max_file_chunk_size` for a more fine-grained control over input data with a large difference in number of events per file.